### PR TITLE
Change withImage to tryLoadImage returning Maybe to handle failure

### DIFF
--- a/docs/Graphics/Canvas.md
+++ b/docs/Graphics/Canvas.md
@@ -57,10 +57,10 @@ Opaque object describing a gradient.
 canvasElementToImageSource :: CanvasElement -> CanvasImageSource
 ```
 
-#### `withImage`
+#### `tryLoadImage`
 
 ``` purescript
-withImage :: forall eff. String -> (CanvasImageSource -> Eff eff Unit) -> Eff eff Unit
+tryLoadImage :: forall eff. String -> (Maybe CanvasImageSource -> Eff (canvas :: Canvas | eff) Unit) -> Eff (canvas :: Canvas | eff) Unit
 ```
 
 Wrapper for asynchronously loading a image file by path and use it in callback, e.g. drawImage

--- a/src/Graphics/Canvas.js
+++ b/src/Graphics/Canvas.js
@@ -7,16 +7,21 @@ exports.canvasElementToImageSource = function(e) {
     return e;
 };
 
-exports.withImage = function (src) {
-  return function(f) {
-        return function () {
-            var img = new Image();
-            img.src = src;
-            img.addEventListener("load", function() {
-                f(img)();
-            }, false);
+exports.tryLoadImageImpl = function (src) {
+  return function(e) {
+        return function(f) {
+            return function () {
+                var img = new Image();
+                img.src = src;
+                img.addEventListener("load", function() {
+                    f(img)();
+                }, false);
+                img.addEventListener("error", function(error) {
+                    e();
+                }, false);
 
-            return {};
+                return {};
+            }
         }
     };
 };

--- a/src/Graphics/Canvas.purs
+++ b/src/Graphics/Canvas.purs
@@ -79,7 +79,7 @@ module Graphics.Canvas
   , restore
   , withContext
 
-  , withImage
+  , tryLoadImage
   , getImageData
   , putImageData
   , putImageDataFull
@@ -128,8 +128,12 @@ foreign import data CanvasGradient :: *
 
 foreign import canvasElementToImageSource :: CanvasElement -> CanvasImageSource
 
+foreign import tryLoadImageImpl :: forall eff. String -> Eff (canvas :: Canvas | eff) Unit -> (CanvasImageSource -> Eff (canvas :: Canvas | eff) Unit) -> Eff (canvas :: Canvas | eff) Unit
+
 -- | Wrapper for asynchronously loading a image file by path and use it in callback, e.g. drawImage
-foreign import withImage :: forall eff. String -> (CanvasImageSource -> Eff eff Unit) -> Eff eff Unit
+tryLoadImage :: forall eff. String -> (Maybe CanvasImageSource -> Eff (canvas :: Canvas | eff) Unit) -> Eff (canvas :: Canvas | eff) Unit
+tryLoadImage path k = tryLoadImageImpl path (k Nothing) (k <<< Just)
+
 
 foreign import getCanvasElementByIdImpl :: 
   forall r eff. Fn3 String


### PR DESCRIPTION
I would like to have the ability to detect when image loading fails. The current withImage function only has a 'load' callback. I added withImage2 which also has an error callback when loading fails. This might be better called withImage', but I wasn't sure how to export the 'prime' symbol. I tried $prime, but that didn't seem to work.