### PR TITLE
Fix setGlobalAlpha

### DIFF
--- a/src/Graphics/Canvas.js
+++ b/src/Graphics/Canvas.js
@@ -158,7 +158,7 @@ exports.setGlobalCompositeOperationImpl = function(ctx) {
 exports.setGlobalAlpha = function(ctx) {
     return function(alpha) {
         return function() {
-            ctx.setGlobalAlpha = alpha;
+            ctx.globalAlpha = alpha;
             return ctx;
         };
     };
@@ -573,4 +573,3 @@ exports.bezierCurveTo = function(bCurve) {
         };
     };
 };
-


### PR DESCRIPTION
This fixes a typo that was (silently) breaking the `setGlobalAlpha` implementation.