### PR TITLE
Add an `Eq` instance for `LineCap`

### DIFF
--- a/src/Graphics/Canvas.purs
+++ b/src/Graphics/Canvas.purs
@@ -226,6 +226,8 @@ foreign import setMiterLimit :: forall eff. Number -> Context2D -> Eff (canvas :
 -- | Enumerates the different types of line cap.
 data LineCap = Round | Square | Butt
 
+derive instance eqLineCap :: Eq LineCap
+
 foreign import setLineCapImpl :: forall eff. String -> Context2D -> Eff (canvas :: CANVAS | eff) Context2D
 
 -- | Set the current line cap type.


### PR DESCRIPTION
I am working on purescript-contrib/purescript-drawing#8, and `OutlineStyle` has a derived `Eq` instance. This instance breaks when I try to add a field of type `LineCap` to it. So, I just added a derived instance, since I see no reason why `LineCap` shouldn't be `Eq`.