### PR TITLE
Add a `Discard` instance for `Context2D`

### DIFF
--- a/src/Graphics/Canvas.purs
+++ b/src/Graphics/Canvas.purs
@@ -382,9 +382,9 @@ foreign import closePath  :: forall eff. Context2D -> Eff (canvas :: CANVAS | ef
 -- | ```
 strokePath :: forall eff a. Context2D -> Eff (canvas :: CANVAS | eff) a -> Eff (canvas :: CANVAS | eff) a
 strokePath ctx path = do
-  _ <- beginPath ctx
+  beginPath ctx
   a <- path
-  _ <- stroke ctx
+  stroke ctx
   pure a
 
 -- | A convenience function for drawing a filled path.
@@ -400,9 +400,9 @@ strokePath ctx path = do
 -- | ```
 fillPath :: forall eff a. Context2D -> Eff (canvas :: CANVAS | eff) a -> Eff (canvas :: CANVAS | eff) a
 fillPath ctx path = do
-  _ <- beginPath ctx
+  beginPath ctx
   a <- path
-  _ <- fill ctx
+  fill ctx
   pure a
 
 -- | A type representing an arc object:
@@ -558,9 +558,9 @@ foreign import restore  :: forall eff. Context2D -> Eff (canvas :: CANVAS | eff)
 -- | ```
 withContext :: forall eff a. Context2D -> Eff (canvas :: CANVAS | eff) a -> Eff (canvas :: CANVAS | eff) a
 withContext ctx action = do
-  _ <- save ctx
+  save ctx
   a <- action
-  _ <- restore ctx
+  restore ctx
   pure a
 
 -- | Get image data for a portion of the canvas.

--- a/src/Graphics/Canvas.purs
+++ b/src/Graphics/Canvas.purs
@@ -128,6 +128,9 @@ foreign import data CanvasElement :: Type
 -- | A 2D graphics context.
 foreign import data Context2D :: Type
 
+instance discardContext2D :: Discard Context2D where
+  discard = bind
+
 -- | An image data object, used to store raster data outside the canvas.
 foreign import data ImageData :: Type
 


### PR DESCRIPTION
Addresses https://github.com/purescript-contrib/purescript-canvas/issues/42

Since operations on `Context2D` return the same object there should be little need to reference it.

See also https://github.com/paf31/purescript-book/issues/102

Note: This PR _could_ be widened in scope to add a `Discard` instance for `Canvas` as well.