### PR TITLE
implement setLineDash support

### DIFF
--- a/src/Graphics/Canvas.js
+++ b/src/Graphics/Canvas.js
@@ -81,6 +81,14 @@ exports.setLineWidth = function(ctx) {
     };
 };
 
+exports.setLineDash = function(ctx) {
+    return function(dash) {
+        return function() {
+            ctx.setLineDash(dash);
+        };
+    };
+};
+
 exports.setFillStyle = function(ctx) {
     return function(style) {
         return function() {

--- a/src/Graphics/Canvas.purs
+++ b/src/Graphics/Canvas.purs
@@ -37,6 +37,7 @@ module Graphics.Canvas
   , canvasToDataURL
 
   , setLineWidth
+  , setLineDash
   , setFillStyle
   , setStrokeStyle
   , setShadowBlur
@@ -202,6 +203,9 @@ foreign import canvasToDataURL :: forall eff. CanvasElement -> Eff (canvas :: CA
 
 -- | Set the current line width.
 foreign import setLineWidth :: forall eff. Context2D -> Number -> Eff (canvas :: CANVAS | eff) Unit
+
+-- | Set the current line dash pattern.
+foreign import setLineDash :: forall eff. Context2D -> Array Number -> Eff (canvas :: CANVAS | eff) Unit
 
 -- | Set the current fill style/color.
 foreign import setFillStyle :: forall eff. Context2D -> String -> Eff (canvas :: CANVAS | eff) Unit


### PR DESCRIPTION
This adds support for setting the line dash pattern, as mentioned in issue #38.  Note that it does not totally resolve that issue since I didn't do `lineDashOffset`.  