### PR TITLE
Add width and height getters for CanvasImageSource

### DIFF
--- a/src/Graphics/Canvas.js
+++ b/src/Graphics/Canvas.js
@@ -526,6 +526,18 @@ export function drawImageFull(ctx) {
   };
 }
 
+export function getCanvasImageSourceWidth(image_source) {
+  return function() {
+    return image_source.width;
+  };
+}
+
+export function getCanvasImageSourceHeight(image_source) {
+  return function() {
+    return image_source.height;
+  };
+}
+
 export function createPatternImpl(ctx) {
   return function(img) {
     return function(repeat) {

--- a/src/Graphics/Canvas.purs
+++ b/src/Graphics/Canvas.purs
@@ -657,6 +657,12 @@ foreign import drawImageScale :: Context2D -> CanvasImageSource -> Number -> Num
 
 foreign import drawImageFull :: Context2D -> CanvasImageSource -> Number -> Number -> Number -> Number -> Number -> Number -> Number -> Number -> Effect Unit
 
+-- | Get the width of an `CanvasImageSource` object.
+foreign import getCanvasImageSourceWidth :: CanvasImageSource -> Number
+
+-- | Get the height of an `CanvasImageSource` object.
+foreign import getCanvasImageSourceHeight :: CanvasImageSource -> Number
+
 -- | Enumerates the different types of pattern repetitions.
 data PatternRepeat = Repeat | RepeatX | RepeatY | NoRepeat
 


### PR DESCRIPTION
**Description of the change**

Add `width` and `height `getters for `CanvasImageSource` object.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
