### PR TITLE
OffscreenCanvas support and Blob creation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,10 @@
     "no-param-reassign": 2,
     "no-return-assign": 2,
     "no-unused-expressions": 2,
+    "no-unused-vars": [
+      "error", 
+      { "argsIgnorePattern": "^_" } 
+    ],
     "no-use-before-define": 2,
     "radix": [2, "always"],
     "indent": [2, 2],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Breaking changes:
 
 New features:
 - Added `imageSmoothingEnabled` to toggle the image smoothing of a `Context2D`.
+- Added `OffscreenCanvas` and its interface.
+- Added `toBlob`, `toBlob'`, and a helper `BlobFormat` type for the arguments to `toBlob'`.
 
 Bugfixes:
 

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/purescript-web/purescript-canvas.git"
   },
   "dependencies": {
-    "purescript-aff": "^8.0.0",
+    "purescript-aff": "^7.0.0",
     "purescript-aff-promise": "^4.0.0",
     "purescript-arraybuffer-types": "^3.0.2",
     "purescript-effect": "^4.0.0",
@@ -29,8 +29,5 @@
     "purescript-maybe": "^6.0.0",
     "purescript-media-types": "^6.0.0",
     "purescript-web-file": "^4.0.0"
-  },
-  "resolutions": {
-    "purescript-aff": "^7.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,8 @@
     "purescript-effect": "^4.0.0",
     "purescript-exceptions": "^6.0.0",
     "purescript-functions": "^6.0.0",
-    "purescript-maybe": "^6.0.0"
+    "purescript-maybe": "^6.0.0",
+    "purescript-media-types": "^6.0.0",
+    "purescript-web-file": "^4.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,7 @@
     "purescript-aff-promise": "^4.0.0",
     "purescript-arraybuffer-types": "^3.0.2",
     "purescript-effect": "^4.0.0",
+    "purescript-either": "^6.1.0",
     "purescript-exceptions": "^6.0.0",
     "purescript-functions": "^6.0.0",
     "purescript-maybe": "^6.0.0",

--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,8 @@
     "url": "https://github.com/purescript-web/purescript-canvas.git"
   },
   "dependencies": {
+    "purescript-aff": "^8.0.0",
+    "purescript-aff-promise": "^4.0.0",
     "purescript-arraybuffer-types": "^3.0.2",
     "purescript-effect": "^4.0.0",
     "purescript-exceptions": "^6.0.0",
@@ -27,5 +29,8 @@
     "purescript-maybe": "^6.0.0",
     "purescript-media-types": "^6.0.0",
     "purescript-web-file": "^4.0.0"
+  },
+  "resolutions": {
+    "purescript-aff": "^7.0.0"
   }
 }

--- a/src/Graphics/Canvas.js
+++ b/src/Graphics/Canvas.js
@@ -475,32 +475,26 @@ export function createImageDataWith(arr) {
 }
 
 export function toBlobDefault(canvas) {
-  return function() {
-    return new Promise(
-      function(resolve, _reject) {
-        canvas.toBlob(resolve);
-      }
-    );
+  return function(cb) {
+    return function() {
+      return canvas.toBlob(cb);
+    };
   };
 }
 
 export function toBlobFormat(canvas, format) {
-  return function() {
-    return new Promise(
-      function(resolve, _reject) {
-        canvas.toBlob(resolve, {type: format});
-      }
-    );
+  return function(cb) {
+    return function() {
+      return canvas.toBlob(cb, {type: format});
+    };
   };
 }
 
 export function toBlobFormatQuality(canvas, format, quality) {
-  return function() {
-    return new Promise(
-      function(resolve, _reject) {
-        canvas.toBlob(resolve, {type: format, quality: quality});
-      }
-    );
+  return function(cb) {
+    return function() {
+      return canvas.toBlob(cb, {type: format, quality: quality});
+    };
   };
 }
 

--- a/src/Graphics/Canvas.js
+++ b/src/Graphics/Canvas.js
@@ -474,16 +474,34 @@ export function createImageDataWith(arr) {
   };
 }
 
-// Wrapper into the error-argument callback style expected by Aff compat,
-// with the error callback ignored.
-function affBlob(_onError, onSuccess) {
-  return function(_cancelError, _onCancelerError, onCancelerSuccess) {
-
+export function toBlobDefault(canvas) {
+  return function() {
+    return new Promise(
+      function(resolve, _reject) {
+        canvas.toBlob(resolve)
+      }
+    );
   };
 }
 
-export function toBlobDefault(canvas) {
+export function toBlobFormat(canvas, format) {
+  return function() {
+    return new Promise(
+      function(resolve, _reject) {
+        canvas.toBlob(resolve, {type: format})
+      }
+    );
+  };
+}
 
+export function toBlobFormatQuality(canvas, format, quality) {
+  return function() {
+    return new Promise(
+      function(resolve, _reject) {
+        canvas.toBlob(resolve, {type: format, quality: quality})
+      }
+    );
+  };
 }
 
 export function drawImage(ctx) {

--- a/src/Graphics/Canvas.js
+++ b/src/Graphics/Canvas.js
@@ -474,6 +474,8 @@ export function createImageDataWith(arr) {
   };
 }
 
+// blob
+
 export function drawImage(ctx) {
   return function(image_source) {
     return function(dx) {

--- a/src/Graphics/Canvas.js
+++ b/src/Graphics/Canvas.js
@@ -474,7 +474,17 @@ export function createImageDataWith(arr) {
   };
 }
 
-// blob
+// Wrapper into the error-argument callback style expected by Aff compat,
+// with the error callback ignored.
+function affBlob(_onError, onSuccess) {
+  return function(_cancelError, _onCancelerError, onCancelerSuccess) {
+
+  };
+}
+
+export function toBlobDefault(canvas) {
+
+}
 
 export function drawImage(ctx) {
   return function(image_source) {

--- a/src/Graphics/Canvas.js
+++ b/src/Graphics/Canvas.js
@@ -478,7 +478,7 @@ export function toBlobDefault(canvas) {
   return function() {
     return new Promise(
       function(resolve, _reject) {
-        canvas.toBlob(resolve)
+        canvas.toBlob(resolve);
       }
     );
   };
@@ -488,7 +488,7 @@ export function toBlobFormat(canvas, format) {
   return function() {
     return new Promise(
       function(resolve, _reject) {
-        canvas.toBlob(resolve, {type: format})
+        canvas.toBlob(resolve, {type: format});
       }
     );
   };
@@ -498,7 +498,7 @@ export function toBlobFormatQuality(canvas, format, quality) {
   return function() {
     return new Promise(
       function(resolve, _reject) {
-        canvas.toBlob(resolve, {type: format, quality: quality})
+        canvas.toBlob(resolve, {type: format, quality: quality});
       }
     );
   };

--- a/src/Graphics/Canvas.purs
+++ b/src/Graphics/Canvas.purs
@@ -127,10 +127,12 @@ import Prelude
 import Effect (Effect)
 import Effect.Exception.Unsafe (unsafeThrow)
 import Data.ArrayBuffer.Types (Uint8ClampedArray)
-import Data.Function.Uncurried (Fn3, runFn3)
+import Data.Function.Uncurried (Fn2, Fn3, runFn2, runFn3)
 import Data.Maybe (Maybe(..))
 import Data.MediaType (MediaType(..))
 import Data.MediaType.Common (imagePNG, imageJPEG, imageGIF)
+import Effect.Aff (Aff)
+import Effect.Aff.Compat (EffectFnAff, fromEffectFnAff)
 
 -- | A canvas HTML element.
 foreign import data CanvasElement :: Type
@@ -669,17 +671,19 @@ blobPNG = Lossless imagePNG
 blobJPEG :: Number -> BlobFormat
 blobJPEG = Lossy imageJPEG
 
--- HOORAY CALLBACK HELLLLLLLL oh boy this needs Aff doesn't it
--- -- | Create a `Blob` of the image data on the canvas, as a PNG file.
--- foreign import toBlob :: CanvasElement -> Effect Blob
+foreign import toBlobDefault :: CanvasElement -> EffectFnAff Blob
 
--- foreign import toBlobFormat :: Fn2 String CanvasElement (Effect Blob)
--- foreign import toBlobFormatQuality :: Fn3 String CanvasElement (Effect Blob)
+-- | Create a `Blob` of the image data on the canvas, as a PNG file.
+toBlob :: CanvasElement -> Aff Blob
+toBlob = fromEffectFnAff <<< toBlobDefault
 
--- -- | Create a `Blob` of the image data on the canvas, in the specified format.
--- toBlob' :: BlobFormat -> CanvasElement -> Effect Blob
--- toBlob' (Lossless (MediaType format)) = runFn2 toBlobFormat format
--- toBlob' (Lossy (MediaType format) quality) = runFn3 toBlobFormatQuality format quality
+foreign import toBlobFormat :: Fn2 String CanvasElement (EffectFnAff Blob)
+foreign import toBlobFormatQuality :: Fn3 String CanvasElement (EffectFnAff Blob)
+
+-- | Create a `Blob` of the image data on the canvas, in the specified format.
+toBlob' :: BlobFormat -> CanvasElement -> Aff Blob
+toBlob' (Lossless (MediaType format)) = fromEffectFnAff <<< runFn2 toBlobFormat format
+toBlob' (Lossy (MediaType format) quality) = fromEffectFnAff <<< runFn3 toBlobFormatQuality format quality
 
 foreign import drawImage :: Context2D -> CanvasImageSource -> Number -> Number -> Effect Unit
 

--- a/src/Graphics/Canvas.purs
+++ b/src/Graphics/Canvas.purs
@@ -25,6 +25,7 @@ module Graphics.Canvas
   , RadialGradient
   , QuadraticCurve
   , BezierCurve
+  , BlobFormat(..)
 
   , getCanvasElementById
   , getContext2D
@@ -99,6 +100,11 @@ module Graphics.Canvas
   , imageDataHeight
   , imageDataBuffer
 
+  -- , toBlob
+  -- , toBlob'
+  , blobPNG
+  , blobJPEG
+
   , canvasElementToImageSource
   , drawImage
   , drawImageScale
@@ -123,6 +129,8 @@ import Effect.Exception.Unsafe (unsafeThrow)
 import Data.ArrayBuffer.Types (Uint8ClampedArray)
 import Data.Function.Uncurried (Fn3, runFn3)
 import Data.Maybe (Maybe(..))
+import Data.MediaType (MediaType(..))
+import Data.MediaType.Common (imagePNG, imageJPEG, imageGIF)
 
 -- | A canvas HTML element.
 foreign import data CanvasElement :: Type
@@ -650,6 +658,28 @@ foreign import imageDataHeight :: ImageData -> Int
 
 -- | Get the underlying buffer from an `ImageData` object.
 foreign import imageDataBuffer :: ImageData -> Uint8ClampedArray
+
+-- | Format arguments for `toBlob'`.
+-- | Quality for lossy compression is given as a `Number` between `0.0` and `1.0`.
+data BlobFormat = Lossless MediaType | Lossy MediaType Number
+
+blobPNG :: BlobFormat
+blobPNG = Lossless imagePNG
+
+blobJPEG :: Number -> BlobFormat
+blobJPEG = Lossy imageJPEG
+
+-- HOORAY CALLBACK HELLLLLLLL oh boy this needs Aff doesn't it
+-- -- | Create a `Blob` of the image data on the canvas, as a PNG file.
+-- foreign import toBlob :: CanvasElement -> Effect Blob
+
+-- foreign import toBlobFormat :: Fn2 String CanvasElement (Effect Blob)
+-- foreign import toBlobFormatQuality :: Fn3 String CanvasElement (Effect Blob)
+
+-- -- | Create a `Blob` of the image data on the canvas, in the specified format.
+-- toBlob' :: BlobFormat -> CanvasElement -> Effect Blob
+-- toBlob' (Lossless (MediaType format)) = runFn2 toBlobFormat format
+-- toBlob' (Lossy (MediaType format) quality) = runFn3 toBlobFormatQuality format quality
 
 foreign import drawImage :: Context2D -> CanvasImageSource -> Number -> Number -> Effect Unit
 

--- a/src/Graphics/Canvas.purs
+++ b/src/Graphics/Canvas.purs
@@ -676,7 +676,7 @@ blobJPEG :: Number -> BlobFormat
 blobJPEG = Lossy imageJPEG
 
 -- Thanks to mikesol for letting me know about makeAff!
-blobCBToAff :: ((Blob -> Effect Unit) -> Effect Unit) -> Aff Blob
+blobCBToAff :: forall a. ((a -> Effect Unit) -> Effect Unit) -> Aff a
 blobCBToAff b = makeAff \cb -> b (cb <<< Right) $> mempty
 
 foreign import toBlobDefault :: CanvasElement -> (Blob -> Effect Unit) -> Effect Unit

--- a/src/Graphics/Canvas.purs
+++ b/src/Graphics/Canvas.purs
@@ -132,7 +132,7 @@ import Data.Maybe (Maybe(..))
 import Data.MediaType (MediaType(..))
 import Data.MediaType.Common (imagePNG, imageJPEG, imageGIF)
 import Effect.Aff (Aff)
-import Effect.Aff.Compat (EffectFnAff, fromEffectFnAff)
+import Control.Promise (Promise, toAffE)
 
 -- | A canvas HTML element.
 foreign import data CanvasElement :: Type
@@ -671,19 +671,19 @@ blobPNG = Lossless imagePNG
 blobJPEG :: Number -> BlobFormat
 blobJPEG = Lossy imageJPEG
 
-foreign import toBlobDefault :: CanvasElement -> EffectFnAff Blob
+foreign import toBlobDefault :: CanvasElement -> Effect (Promise Blob)
 
 -- | Create a `Blob` of the image data on the canvas, as a PNG file.
 toBlob :: CanvasElement -> Aff Blob
-toBlob = fromEffectFnAff <<< toBlobDefault
+toBlob = toAffE <<< toBlobDefault
 
-foreign import toBlobFormat :: Fn2 String CanvasElement (EffectFnAff Blob)
-foreign import toBlobFormatQuality :: Fn3 String CanvasElement (EffectFnAff Blob)
+foreign import toBlobFormat :: Fn2 String CanvasElement (Effect (Promise Blob))
+foreign import toBlobFormatQuality :: Fn3 String CanvasElement (Effect (Promise Blob))
 
 -- | Create a `Blob` of the image data on the canvas, in the specified format.
 toBlob' :: BlobFormat -> CanvasElement -> Aff Blob
-toBlob' (Lossless (MediaType format)) = fromEffectFnAff <<< runFn2 toBlobFormat format
-toBlob' (Lossy (MediaType format) quality) = fromEffectFnAff <<< runFn3 toBlobFormatQuality format quality
+toBlob' (Lossless (MediaType format)) = toAffE <<< runFn2 toBlobFormat format
+toBlob' (Lossy (MediaType format) quality) = toAffE <<< runFn3 toBlobFormatQuality format quality
 
 foreign import drawImage :: Context2D -> CanvasImageSource -> Number -> Number -> Effect Unit
 

--- a/src/Graphics/Canvas/Offscreen.js
+++ b/src/Graphics/Canvas/Offscreen.js
@@ -16,6 +16,18 @@ export function getWidth(offscreen) {
   };
 }
 
+export function setHeightImpl(offscreen, h) {
+  return function() {
+    offscreen.height = h;
+  };
+}
+
+export function setWidthImpl(offscreen, w) {
+  return function() {
+    offscreen.width = w;
+  };
+}
+
 export function toBlobDefault(offscreen) {
   return function() {
     return offscreen.toBlob();

--- a/src/Graphics/Canvas/Offscreen.js
+++ b/src/Graphics/Canvas/Offscreen.js
@@ -1,3 +1,9 @@
+export function createOffscreenCanvasImpl(width, height) {
+  return function() {
+    return OffscreenCanvas(width, height);
+  };
+}
+
 export function getHeight(offscreen) {
   return function() {
     return offscreen.height;

--- a/src/Graphics/Canvas/Offscreen.js
+++ b/src/Graphics/Canvas/Offscreen.js
@@ -24,6 +24,6 @@ export function toBlob(offscreen) {
 
 export function getContext2D(offscreen) {
   return function(){
-    return offscreen.getContext();
+    return offscreen.getContext('2d');
   };
 }

--- a/src/Graphics/Canvas/Offscreen.js
+++ b/src/Graphics/Canvas/Offscreen.js
@@ -16,14 +16,26 @@ export function getWidth(offscreen) {
   };
 }
 
-export function toBlob(offscreen) {
-  return function(){
+export function toBlobDefault(offscreen) {
+  return function() {
     return offscreen.toBlob();
   };
 }
 
+export function toBlobFormat(offscreen, format) {
+  return function() {
+    return offscreen.toBlob({type: format});
+  };
+}
+
+export function toBlobFormatQuality(offscreen, format, quality) {
+  return function() {
+    return offscreen.toBlob({type: format, quality: quality});
+  };
+}
+
 export function getContext2D(offscreen) {
-  return function(){
-    return offscreen.getContext('2d');
+  return function() {
+    return offscreen.getContext("2d");
   };
 }

--- a/src/Graphics/Canvas/Offscreen.js
+++ b/src/Graphics/Canvas/Offscreen.js
@@ -1,6 +1,6 @@
 export function createOffscreenCanvas(dims) {
   return function() {
-    return OffscreenCanvas(dims.width, dims.height);
+    return new OffscreenCanvas(dims.width, dims.height);
   };
 }
 

--- a/src/Graphics/Canvas/Offscreen.js
+++ b/src/Graphics/Canvas/Offscreen.js
@@ -1,6 +1,6 @@
-export function createOffscreenCanvasImpl(width, height) {
+export function createOffscreenCanvas(dims) {
   return function() {
-    return OffscreenCanvas(width, height);
+    return OffscreenCanvas(dims.width, dims.height);
   };
 }
 

--- a/src/Graphics/Canvas/Offscreen.js
+++ b/src/Graphics/Canvas/Offscreen.js
@@ -1,0 +1,23 @@
+export function getHeight(offscreen) {
+  return function() {
+    return offscreen.height;
+  };
+}
+
+export function getWidth(offscreen) {
+  return function() {
+    return offscreen.width;
+  };
+}
+
+export function toBlob(offscreen) {
+  return function(){
+    return offscreen.toBlob();
+  };
+}
+
+export function getContext2D(offscreen) {
+  return function(){
+    return offscreen.getContext();
+  };
+}

--- a/src/Graphics/Canvas/Offscreen.purs
+++ b/src/Graphics/Canvas/Offscreen.purs
@@ -4,14 +4,16 @@ module Graphics.Canvas.Offscreen
  , getHeight
  , getWidth
  , toBlob
- --, toBlob'
+ , toBlob'
  , getContext2D
  -- , toImageBitmap
  ) where
 
 import Effect (Effect)
 import Web.File.Blob (Blob)
-import Graphics.Canvas (Context2D)
+import Graphics.Canvas (Context2D, BlobFormat(..))
+import Data.MediaType (MediaType(..))
+import Data.Function (Fn2, Fn3, runFn2, runFn3)
 
 -- | An OffscreenCanvas object, representing a virtual canvas which does not exist
 -- | in the document and will not be rendered.
@@ -26,14 +28,21 @@ foreign import getHeight :: OffscreenCanvas -> Effect Int
 -- | Gets the logical width in pixels of the virtual canvas.
 foreign import getWidth :: OffscreenCanvas -> Effect Int
 
--- | Creates a `Blob` of the image data on the virtual canvas, as a PNG file.
+-- | Create a `Blob` of the image data on the virtual canvas, as a PNG file.
 foreign import toBlob :: OffscreenCanvas -> Effect Blob
 
--- -- | Creates a `Blob` of the image data on the virtual canvas, in the specified format.
--- TODO: add blob stuff to normal canvas too ;_; because I feel like this merits a type for
--- both restricting MediaTypes and for capturing which ones do and don't take a quality
+foreign import toBlobFormat :: Fn2 String OffscreenCanvas (Effect Blob)
+foreign import toBlobFormatQuality :: Fn3 String OffscreenCanvas (Effect Blob)
+
+-- | Create a `Blob` of the image data on the virtual canvas, in the specified format.
+toBlob' :: BlobFormat -> OffscreenCanvas -> Effect Blob
+toBlob' (Lossless (MediaType format)) = runFn2 toBlobFormat format
+toBlob' (Lossy (MediaType format) quality) = runFn3 toBlobFormatQuality format quality
 
 -- | Get the 2D graphics context for a virtual canvas element.
+-- | Although this is a different type (`OffscreenCanvasRenderingContext2D`)
+-- | in the underlying JavaScript, `Context2D` does not expose any of the
+-- | discrepancies in functionality.
 foreign import getContext2D :: OffscreenCanvas -> Effect Context2D
 
 -- TODO: focus long enough to figure out the image bitmap thing

--- a/src/Graphics/Canvas/Offscreen.purs
+++ b/src/Graphics/Canvas/Offscreen.purs
@@ -65,4 +65,4 @@ toBlob' (Lossy (MediaType format) quality) = toAffE <<< runFn3 toBlobFormatQuali
 -- | discrepancies in functionality.
 foreign import getContext2D :: OffscreenCanvas -> Effect Context2D
 
--- TODO: focus long enough to figure out the image bitmap thing
+-- transferToImageBitmap not added because ImageBitmap seems like a very large can of worms!

--- a/src/Graphics/Canvas/Offscreen.purs
+++ b/src/Graphics/Canvas/Offscreen.purs
@@ -1,9 +1,35 @@
-module Canvas.Offscreen
+module Graphics.Canvas.Offscreen
  ( OffscreenCanvas
  , getHeight
  , getWidth
  , toBlob
- , getContext
- , transferToImageBitmap
+ --, toBlob'
+ , getContext2D
+ -- , toImageBitmap
  ) where
 
+import Effect (Effect)
+import Web.File.Blob (Blob)
+import Graphics.Canvas (Context2D)
+
+-- | An OffscreenCanvas object, representing a virtual canvas which does not exist
+-- | in the document and will not be rendered.
+foreign import data OffscreenCanvas :: Type
+
+-- | Gets the logical height in pixels of the virtual canvas.
+foreign import getHeight :: OffscreenCanvas -> Effect Int
+
+-- | Gets the logical width in pixels of the virtual canvas.
+foreign import getWidth :: OffscreenCanvas -> Effect Int
+
+-- | Creates a `Blob` of the image data on the virtual canvas, as a PNG file.
+foreign import toBlob :: OffscreenCanvas -> Effect Blob
+
+-- -- | Creates a `Blob` of the image data on the virtual canvas, in the specified format.
+-- TODO: add blob stuff to normal canvas too ;_; because I feel like this merits a type for
+-- both restricting MediaTypes and for capturing which ones do and don't take a quality
+
+-- | Get the 2D graphics context for a virtual canvas element.
+foreign import getContext2D :: OffscreenCanvas -> Effect Context2D
+
+-- TODO: focus long enough to figure out the image bitmap thing

--- a/src/Graphics/Canvas/Offscreen.purs
+++ b/src/Graphics/Canvas/Offscreen.purs
@@ -1,0 +1,9 @@
+module Canvas.Offscreen
+ ( OffscreenCanvas
+ , getHeight
+ , getWidth
+ , toBlob
+ , getContext
+ , transferToImageBitmap
+ ) where
+

--- a/src/Graphics/Canvas/Offscreen.purs
+++ b/src/Graphics/Canvas/Offscreen.purs
@@ -23,13 +23,13 @@ import Control.Promise (Promise, toAffE)
 -- | in the document and will not be rendered.
 foreign import data OffscreenCanvas :: Type
 
--- | Creates a virtual canvas with the given width and height.
+-- | Create a virtual canvas with the given width and height.
 foreign import createOffscreenCanvas :: { width :: Int, height :: Int } -> (Effect OffscreenCanvas)
 
--- | Gets the logical height in pixels of the virtual canvas.
+-- | Get the logical height in pixels of the virtual canvas.
 foreign import getHeight :: OffscreenCanvas -> Effect Int
 
--- | Gets the logical width in pixels of the virtual canvas.
+-- | Get the logical width in pixels of the virtual canvas.
 foreign import getWidth :: OffscreenCanvas -> Effect Int
 
 foreign import toBlobDefault :: OffscreenCanvas -> Effect (Promise Blob)

--- a/src/Graphics/Canvas/Offscreen.purs
+++ b/src/Graphics/Canvas/Offscreen.purs
@@ -12,17 +12,13 @@ module Graphics.Canvas.Offscreen
 import Effect (Effect)
 import Web.File.Blob (Blob)
 import Graphics.Canvas (Context2D)
-import Data.Function.Uncurried (Fn2, runFn2)
 
 -- | An OffscreenCanvas object, representing a virtual canvas which does not exist
 -- | in the document and will not be rendered.
 foreign import data OffscreenCanvas :: Type
 
-foreign import createOffscreenCanvasImpl :: Fn2 Int Int (Effect OffscreenCanvas)
-
 -- | Creates a virtual canvas with the given width and height.
-createOffscreenCanvas :: Int -> Int -> Effect OffscreenCanvas
-createOffscreenCanvas = runFn2 createOffscreenCanvasImpl
+foreign import createOffscreenCanvas :: { width :: Int, height :: Int } -> (Effect OffscreenCanvas)
 
 -- | Gets the logical height in pixels of the virtual canvas.
 foreign import getHeight :: OffscreenCanvas -> Effect Int

--- a/src/Graphics/Canvas/Offscreen.purs
+++ b/src/Graphics/Canvas/Offscreen.purs
@@ -3,6 +3,8 @@ module Graphics.Canvas.Offscreen
  , createOffscreenCanvas
  , getHeight
  , getWidth
+ , setHeight
+ , setWidth
  , toBlob
  , toBlob'
  , getContext2D
@@ -31,6 +33,17 @@ foreign import getHeight :: OffscreenCanvas -> Effect Int
 
 -- | Get the logical width in pixels of the virtual canvas.
 foreign import getWidth :: OffscreenCanvas -> Effect Int
+
+foreign import setHeightImpl :: Fn2 OffscreenCanvas Int (Effect Unit)
+foreign import setWidthImpl :: Fn2 OffscreenCanvas Int (Effect Unit)
+
+-- | Set the logical height in pixels of the virtual canvas.
+setHeight :: OffscreenCanvas -> Int -> Effect Unit
+setHeight = runFn2 setHeightImpl
+
+-- | Set the logical width in pixels of the virtual canvas.
+setWidth :: OffscreenCanvas -> Int -> Effect Unit
+setWidth = runFn2 setWidthImpl
 
 foreign import toBlobDefault :: OffscreenCanvas -> Effect (Promise Blob)
 

--- a/src/Graphics/Canvas/Offscreen.purs
+++ b/src/Graphics/Canvas/Offscreen.purs
@@ -1,5 +1,6 @@
 module Graphics.Canvas.Offscreen
  ( OffscreenCanvas
+ , createOffscreenCanvas
  , getHeight
  , getWidth
  , toBlob
@@ -11,10 +12,17 @@ module Graphics.Canvas.Offscreen
 import Effect (Effect)
 import Web.File.Blob (Blob)
 import Graphics.Canvas (Context2D)
+import Data.Function.Uncurried (Fn2, runFn2)
 
 -- | An OffscreenCanvas object, representing a virtual canvas which does not exist
 -- | in the document and will not be rendered.
 foreign import data OffscreenCanvas :: Type
+
+foreign import createOffscreenCanvasImpl :: Fn2 Int Int (Effect OffscreenCanvas)
+
+-- | Creates a virtual canvas with the given width and height.
+createOffscreenCanvas :: Int -> Int -> Effect OffscreenCanvas
+createOffscreenCanvas = runFn2 createOffscreenCanvasImpl
 
 -- | Gets the logical height in pixels of the virtual canvas.
 foreign import getHeight :: OffscreenCanvas -> Effect Int


### PR DESCRIPTION
**Description of the change**

Adds a new module `Graphics.Canvas.Offscreen` containing bindings to the `OffscreenCanvas` interface, and adds bindings for `HTMLCanvasElement.toBlob`.

Semi-solves #75 -- doesn't directly allow creation of canvas elements, but gives a better purpose-built API for @thanacles' use case.

One thing that I haven't added because it somewhat worries me to add is `transferControlToOffscreen`. Given that it errors if the canvas has a context already, and getting a context on the canvas errors if it's been transferred, I'm unsure if simply allowing the JS to error within `Effect` is appropriate. Maybe it should just be prefixed `unsafe`?

I have also not added `transferToImageBitmap`, because there's no existing bindings for the `ImageBitmap` type and adding them seems like another far more involved PR's worth of work in and of itself.

I'm also worried about the `aff` `7.1.0` dependency imposed by `aff-promise`, mostly because I don't actually know how package sets work. I tried to use `js-promise-aff`, but Bower couldn't find it. I imagine it wouldn't be too difficult to remove the dependency entirely, but I'm in way over my head with anything async.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
