### PR TITLE
Type width and height of canvas element as `Int`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Notable changes to this project are documented in this file. The format is based
 ## [Unreleased]
 
 Breaking changes:
+- Changed types of width and height from Number to Int
 
 New features:
 - Added `imageSmoothingEnabled` to toggle the image smoothing of a `Context2D`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Notable changes to this project are documented in this file. The format is based
 ## [Unreleased]
 
 Breaking changes:
-- Changed types of width and height from Number to Int
+- Changed types of width and height from Number to Int. The API guarantees that these values are integers as is, and even silently rounds non-integers if given.
 
 New features:
 - Added `imageSmoothingEnabled` to toggle the image smoothing of a `Context2D`.

--- a/src/Graphics/Canvas.purs
+++ b/src/Graphics/Canvas.purs
@@ -172,19 +172,19 @@ getCanvasElementById elId = runFn3 getCanvasElementByIdImpl elId Just Nothing
 foreign import getContext2D :: CanvasElement -> Effect Context2D
 
 -- | Get the canvas width in pixels.
-foreign import getCanvasWidth :: CanvasElement -> Effect Number
+foreign import getCanvasWidth :: CanvasElement -> Effect Int
 
 -- | Get the canvas height in pixels.
-foreign import getCanvasHeight :: CanvasElement -> Effect Number
+foreign import getCanvasHeight :: CanvasElement -> Effect Int
 
 -- | Set the canvas width in pixels.
-foreign import setCanvasWidth :: CanvasElement -> Number -> Effect Unit
+foreign import setCanvasWidth :: CanvasElement -> Int -> Effect Unit
 
 -- | Set the canvas height in pixels.
-foreign import setCanvasHeight :: CanvasElement -> Number -> Effect Unit
+foreign import setCanvasHeight :: CanvasElement -> Int -> Effect Unit
 
 -- | Canvas dimensions (width and height) in pixels.
-type Dimensions = { width :: Number, height :: Number }
+type Dimensions = { width :: Int, height :: Int }
 
 -- | Get the canvas dimensions in pixels.
 getCanvasDimensions :: CanvasElement -> Effect Dimensions


### PR DESCRIPTION
**Description of the change**

The Canvas API guarantees and enforces that the width and height of the canvas element are integers; this PR changes the type declarations of `getWidth`, `getHeight`, `setWidth`, `setHeight`, and `Dimensions` to reflect this. Although this is an extremely breaking change, it seems like it ought to be made eventually.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
